### PR TITLE
turning wbc_modem node on in usb-modem-overlays on wb6.x

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-dt-overlays (1.5.0) stable; urgency=medium
+
+  * turning on wbc_modem node in wb6's: sim5300e, sim7000e, sim7000e-n overlays
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 21 Feb 2021 10:27:12 +0300
+
 wb-dt-overlays (1.4.0) stable; urgency=medium
 
   * add dependency on linux-image-wb7

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/wirenboard/wb-dt-overlays/
 
 Package: wb-dt-overlays
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, linux-image-wb2 (>= 4.9+wb20180718154205) | linux-image-wb6 (>= 4.9+wb20180718154205) | linux-image-wb7
+Depends: ${shlibs:Depends}, ${misc:Depends}, linux-image-wb2 (>= 4.9+wb20180718154205) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb108~~)
 Description: Device tree overlays for Wiren Board devices

--- a/src/gsm-usb.dtsi
+++ b/src/gsm-usb.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Dummy overlay which turns modem-usb node on
+ * wb-gsm looks here in userspace
+ */
+
+/ {
+    fragment-usb {
+        target = <&wbc_modem>;
+
+        __overlay__ {
+            status = "okay";
+        };
+    };
+};

--- a/src/wb6-gsm-sim5300e.dtso
+++ b/src/wb6-gsm-sim5300e.dtso
@@ -2,4 +2,5 @@
 /plugin/;
 
 #include "wb6-gsm.dtsi"
+#include "gsm-usb.dtsi"
 #include "gsm-sim5300e.dtsi"

--- a/src/wb6-gsm-sim7000e-n.dtso
+++ b/src/wb6-gsm-sim7000e-n.dtso
@@ -3,4 +3,5 @@
 /plugin/;
 
 #include "wb6-gsm.dtsi"
+#include "gsm-usb.dtsi"
 #include "gsm-sim7000e-n.dtsi"

--- a/src/wb6-gsm-sim7000e.dtso
+++ b/src/wb6-gsm-sim7000e.dtso
@@ -2,4 +2,5 @@
 /plugin/;
 
 #include "wb6-gsm.dtsi"
+#include "gsm-usb.dtsi"
 #include "gsm-sim7000e.dtsi"


### PR DESCRIPTION
в wb6.x теперь тоже новая логика wb-gsm, как обсуждали
оверлей только с uart (sim800) : /dev/ttyGSM - симлинк на uart (делается udev'ом)
оверлей uart + usb (sim5300e) : /dev/ttyGSM - симлинк на первый ответивший usb

даже ничего не сломалось