### PR TITLE
wb7: add wb7-noeth1 overlay

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-dt-overlays (1.6.0) stable; urgency=medium
+
+  * wb7: add wb7-noeth1 overlay
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 15 Nov 2022 21:17:59 +0600
+
 wb-dt-overlays (1.5.0) stable; urgency=medium
 
   * turning on wbc_modem node in wb6's: sim5300e, sim7000e, sim7000e-n overlays

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-dt-overlays (1.6.0) stable; urgency=medium
 
-  * wb7: add wb7-noeth1 overlay
+  * add generic noeth1 overlay
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 15 Nov 2022 21:17:59 +0600
 

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/wirenboard/wb-dt-overlays/
 
 Package: wb-dt-overlays
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, linux-image-wb2 (>= 4.9+wb20180718154205) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb108~~)
+Depends: ${shlibs:Depends}, ${misc:Depends}, linux-image-wb2 (>= 4.9+wb20180718154205) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb122~~)
 Description: Device tree overlays for Wiren Board devices

--- a/src/noeth1.dtso
+++ b/src/noeth1.dtso
@@ -2,10 +2,10 @@
 /plugin/;
 
 / {
-    description = "Disable eth1 on Wiren Board";
+    description = "Disable ethernet1";
 
     fragment@0 {
-        target = <&wb_eth1>;
+        target = <&ethernet1>;
         __overlay__ {
             status = "disabled";
         };

--- a/src/wb7-noeth1.dtso
+++ b/src/wb7-noeth1.dtso
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    description = "Disable eth1 on Wiren Board";
+
+    fragment@0 {
+        target = <&wb_eth1>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+};


### PR DESCRIPTION
Понадобилось для новой партии контроллеров с одним ethernet. Поддержка в ядре отдельным PR. Будет перенесено в релиз.