### PR TITLE
add dependency to backported kernel from wb-2207 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-dt-overlays (1.6.0+wb1) stable; urgency=medium
+
+  * add dependency to backported kernel from wb-2207 release
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 17 Nov 2022 16:59:35 +0600
+
 wb-dt-overlays (1.6.0) stable; urgency=medium
 
   * add generic noeth1 overlay

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/wirenboard/wb-dt-overlays/
 
 Package: wb-dt-overlays
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, linux-image-wb2 (>= 4.9+wb20180718154205) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb122~~)
+Depends: ${shlibs:Depends}, ${misc:Depends}, linux-image-wb2 (>= 4.9+wb20180718154205) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb120+wb1~~)
 Description: Device tree overlays for Wiren Board devices


### PR DESCRIPTION
Из-за зависимости от ядра из testing сломался релиз. Проглядел, исправляюсь